### PR TITLE
[FEAT] 메인 도장판 화면용 StampRepository 정의 및 mock 클래스 구현

### DIFF
--- a/app/src/main/java/com/polzzak_android/data/remote/model/StampBoardGroup.kt
+++ b/app/src/main/java/com/polzzak_android/data/remote/model/StampBoardGroup.kt
@@ -1,0 +1,9 @@
+package com.polzzak_android.data.remote.model
+
+/**
+ * 도장판 목록 조회 요청 시 넘겨야 하는 목록 종류
+ */
+enum class StampBoardGroup(val value: String) {
+    IN_PROGRESS("in_progress"),
+    ENDED("ended")
+}

--- a/app/src/main/java/com/polzzak_android/data/remote/model/response/StampBoardListResponse.kt
+++ b/app/src/main/java/com/polzzak_android/data/remote/model/response/StampBoardListResponse.kt
@@ -1,0 +1,30 @@
+package com.polzzak_android.data.remote.model.response
+
+data class StampBoardListResponse(
+    override val code: Int?,
+    override val messages: List<String>?,
+    override val data: StampBoardListResponseData?,
+) : BaseResponse<StampBoardListResponse.StampBoardListResponseData> {
+
+    data class StampBoardListResponseData(
+        val partner: PartnerData,
+        val stampBoardSummaries: List<StampBoardSummaryData>
+    ) {
+        data class PartnerData(
+            val memberId: Int,
+            val nickname: String,
+            val memberType: String,
+            val profileUrl: String
+        )
+
+        data class StampBoardSummaryData(
+            val stampBoardId: Int,
+            val name: String,
+            val currentStampCount: Int,
+            val goalStampCount: Int,
+            val reward: String,
+            val missionRequestCount: Int,
+            val status: String
+        )
+    }
+}

--- a/app/src/main/java/com/polzzak_android/data/repository/StampRepository.kt
+++ b/app/src/main/java/com/polzzak_android/data/repository/StampRepository.kt
@@ -1,0 +1,67 @@
+package com.polzzak_android.data.repository
+
+import com.polzzak_android.common.model.ApiResult
+import com.polzzak_android.data.remote.model.StampBoardGroup
+import com.polzzak_android.data.remote.model.response.StampBoardListResponse
+
+interface StampRepository {
+    /**
+     * 도장판 목록 리스트 요청
+     */
+    suspend fun getStampBoardList(
+        stampBoardGroup: StampBoardGroup,
+        memberId: String = ""
+    ): ApiResult<List<StampBoardListResponse.StampBoardListResponseData>>
+}
+
+/**
+ * fake data 받기 위한 구현클래스
+ */
+class MockStampRepositoryImpl : StampRepository {
+    override suspend fun getStampBoardList(
+        stampBoardGroup: StampBoardGroup,
+        memberId: String
+    ): ApiResult<List<StampBoardListResponse.StampBoardListResponseData>> {
+        val fakeData = listOf(
+            StampBoardListResponse.StampBoardListResponseData(
+                partner = StampBoardListResponse.StampBoardListResponseData.PartnerData(
+                    memberId = 11,
+                    nickname = "아이 1",
+                    memberType = "KID",
+                    profileUrl = "url"
+                ),
+                stampBoardSummaries = listOf(
+                    StampBoardListResponse.StampBoardListResponseData.StampBoardSummaryData(
+                        stampBoardId = 1,
+                        name = "도장판 1",
+                        currentStampCount = 13,
+                        goalStampCount = 30,
+                        reward = "콘서트",
+                        missionRequestCount = 5,
+                        status = "progress"
+                    ),
+                    StampBoardListResponse.StampBoardListResponseData.StampBoardSummaryData(
+                        stampBoardId = 3,
+                        name = "도장판 3",
+                        currentStampCount = 30,
+                        goalStampCount = 30,
+                        reward = "칭찬",
+                        missionRequestCount = 0,
+                        status = "completed"
+                    )
+                )
+            ),
+            StampBoardListResponse.StampBoardListResponseData(
+                partner = StampBoardListResponse.StampBoardListResponseData.PartnerData(
+                    memberId = 12,
+                    nickname = "아이 2",
+                    memberType = "KID",
+                    profileUrl = "image_url"
+                ),
+                stampBoardSummaries = emptyList()
+            )
+        )
+
+        return ApiResult.success(fakeData)
+    }
+}


### PR DESCRIPTION
issue: #24
* 도장판 목록 api 응답으로 사용할 StampBoardListResponse 정의
* StampRespository 인터페이스 정의
* fake data 반환하는 MockStampRepositoryImpl 구현

## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #24 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
