### PR TITLE
[FEAT] 회원가입 네비게이션 그래프 분리

### DIFF
--- a/app/src/main/java/com/polzzak_android/data/remote/UserModule.kt
+++ b/app/src/main/java/com/polzzak_android/data/remote/UserModule.kt
@@ -1,0 +1,25 @@
+package com.polzzak_android.data.remote
+
+import com.polzzak_android.data.remote.service.UserService
+import com.polzzak_android.data.repository.UserRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UserModule {
+    @Singleton
+    @Provides
+    fun provideUserService(@Named("Polzzak") retrofit: Retrofit): UserService =
+        retrofit.create(UserService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideUserRepository(userService: UserService): UserRepository =
+        UserRepository(userService = userService)
+}

--- a/app/src/main/java/com/polzzak_android/data/remote/model/response/UserResponse.kt
+++ b/app/src/main/java/com/polzzak_android/data/remote/model/response/UserResponse.kt
@@ -1,0 +1,20 @@
+package com.polzzak_android.data.remote.model.response
+
+import com.google.gson.annotations.SerializedName
+import com.polzzak_android.data.remote.model.RemoteMemberType
+
+data class UserResponse(
+    override val code: Int?,
+    override val messages: List<String>?,
+    override val data: UserResponseData?
+) : BaseResponse<UserResponse.UserResponseData> {
+
+    data class UserResponseData(
+        @SerializedName("nickname")
+        val nickName: String,
+        @SerializedName("memberType")
+        val memberType: RemoteMemberType,
+        @SerializedName("profileUrl")
+        val profileUrl: String
+    )
+}

--- a/app/src/main/java/com/polzzak_android/data/remote/service/AuthService.kt
+++ b/app/src/main/java/com/polzzak_android/data/remote/service/AuthService.kt
@@ -4,14 +4,12 @@ import com.polzzak_android.data.remote.model.request.LoginRequest
 import com.polzzak_android.data.remote.model.response.CheckNickNameValidationResponse
 import com.polzzak_android.data.remote.model.response.LoginResponse
 import com.polzzak_android.data.remote.model.response.SignUpResponse
-import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
-import retrofit2.http.Multipart
+import retrofit2.http.Header
 import retrofit2.http.POST
-import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -27,10 +25,9 @@ interface AuthService {
         @Query("value") nickName: String,
     ): Response<CheckNickNameValidationResponse>
 
-    @Multipart
     @POST("/api/v1/auth/register")
     suspend fun requestSignUp(
-        @Part("registerRequest") registerRequest: RequestBody,
-        @Part image: MultipartBody.Part?
+        @Header("Content-Type") contentType: String,
+        @Body requestBody: RequestBody
     ): Response<SignUpResponse>
 }

--- a/app/src/main/java/com/polzzak_android/data/remote/service/UserService.kt
+++ b/app/src/main/java/com/polzzak_android/data/remote/service/UserService.kt
@@ -1,0 +1,14 @@
+package com.polzzak_android.data.remote.service
+
+import com.polzzak_android.data.remote.model.response.UserResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Header
+
+
+interface UserService {
+    @GET("/api/v1/users/me")
+    fun requestUserInfo(
+        @Header("Authorization") accessToken: String,
+    ): Response<UserResponse>
+}

--- a/app/src/main/java/com/polzzak_android/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/polzzak_android/data/repository/UserRepository.kt
@@ -1,0 +1,14 @@
+package com.polzzak_android.data.repository
+
+import com.polzzak_android.data.remote.model.response.UserResponse
+import com.polzzak_android.data.remote.service.UserService
+import retrofit2.Response
+import javax.inject.Inject
+
+class UserRepository @Inject constructor(
+    private val userService: UserService
+) {
+    suspend fun requestUser(accessToken: String): Response<UserResponse> {
+        return userService.requestUserInfo(accessToken = accessToken)
+    }
+}

--- a/app/src/main/java/com/polzzak_android/presentation/auth/login/LoginFragment.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/auth/login/LoginFragment.kt
@@ -3,14 +3,16 @@ package com.polzzak_android.presentation.auth.login
 import android.os.Bundle
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.kakao.sdk.auth.model.OAuthToken
 import com.polzzak_android.R
-import com.polzzak_android.presentation.common.MainViewModel
-import com.polzzak_android.presentation.common.base.BaseFragment
-import com.polzzak_android.presentation.common.util.getSocialLoginManager
-import com.polzzak_android.presentation.common.model.ApiResult
 import com.polzzak_android.common.util.livedata.EventWrapperObserver
 import com.polzzak_android.databinding.FragmentLoginBinding
 import com.polzzak_android.presentation.auth.signup.SignUpFragment
+import com.polzzak_android.presentation.common.MainViewModel
+import com.polzzak_android.presentation.common.base.BaseFragment
+import com.polzzak_android.presentation.common.model.ApiResult
+import com.polzzak_android.presentation.common.util.getSocialLoginManager
 import dagger.hilt.android.AndroidEntryPoint
 
 //TODO google login release keystore 추가(현재 debug keystore만 사용 중)
@@ -19,14 +21,31 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>() {
     override val layoutResId = R.layout.fragment_login
 
     private val mainViewModel by viewModels<MainViewModel>(ownerProducer = { requireActivity() })
+    private val loginViewModel by viewModels<LoginViewModel>()
+
+    private val googleLoginSuccessCallback: (GoogleSignInAccount) -> Unit = { googleSignInAccount ->
+        googleSignInAccount.serverAuthCode?.let { authCode ->
+            loginViewModel.requestGoogleLogin(authCode = authCode)
+        } ?: run {
+            //TODO id값, authcode가 안내려온 경우
+        }
+    }
+    private val kakaoLoginSuccessCallback: (OAuthToken) -> Unit = { token ->
+        loginViewModel.requestKakaoLogin(accessToken = token.accessToken)
+    }
 
     override fun initView() {
         super.initView()
+        val googleLoginHelper = getSocialLoginManager()?.googleLoginHelper
+        val kakaoLoginHelper = getSocialLoginManager()?.kakaoLoginHelper
+
+        googleLoginHelper?.registerLoginSuccessCallback(callback = googleLoginSuccessCallback)
+        kakaoLoginHelper?.registerLoginSuccessCallback(callback = kakaoLoginSuccessCallback)
         binding.tvBtnStartGoogle.setOnClickListener {
-            getSocialLoginManager()?.requestLoginGoogle()
+            googleLoginHelper?.requestLogin()
         }
         binding.tvBtnStartKakao.setOnClickListener {
-            getSocialLoginManager()?.requestLoginKakao()
+            kakaoLoginHelper?.requestLogin()
         }
 
         // todo: 보호자 프래그먼트 이동 임시 나중에 삭제
@@ -35,9 +54,17 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>() {
         }
     }
 
+    override fun onDestroyView() {
+        getSocialLoginManager()?.run {
+            googleLoginHelper?.unregisterLoginSuccessCallback(callback = googleLoginSuccessCallback)
+            kakaoLoginHelper?.unregisterLoginSuccessCallback(callback = kakaoLoginSuccessCallback)
+        }
+        super.onDestroyView()
+    }
+
     override fun initObserver() {
         super.initObserver()
-        mainViewModel.loginInfoLiveData.observe(viewLifecycleOwner, EventWrapperObserver {
+        loginViewModel.loginInfoLiveData.observe(viewLifecycleOwner, EventWrapperObserver {
             //TODO api 반환값 처리
             when (it) {
                 is ApiResult.Loading -> {

--- a/app/src/main/java/com/polzzak_android/presentation/auth/login/LoginViewModel.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/auth/login/LoginViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.polzzak_android.common.util.livedata.EventWrapper
 import com.polzzak_android.data.repository.LoginRepository
+import com.polzzak_android.data.repository.UserRepository
 import com.polzzak_android.presentation.auth.login.model.LoginConvertor.toLoginInfoUiModel
 import com.polzzak_android.presentation.auth.login.model.LoginInfoUiModel
 import com.polzzak_android.presentation.auth.model.SocialLoginType
@@ -20,11 +21,11 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val loginRepository: LoginRepository
+    private val loginRepository: LoginRepository,
+    private val userRepository: UserRepository
 ) : ViewModel() {
     private val _loginInfoLiveData = MutableLiveData<EventWrapper<ApiResult<LoginInfoUiModel>>>()
     val loginInfoLiveData: LiveData<EventWrapper<ApiResult<LoginInfoUiModel>>> = _loginInfoLiveData
-
 
     private var loginJob: Job? = null
 

--- a/app/src/main/java/com/polzzak_android/presentation/auth/login/LoginViewModel.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/auth/login/LoginViewModel.kt
@@ -1,0 +1,62 @@
+package com.polzzak_android.presentation.auth.login
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.polzzak_android.common.util.livedata.EventWrapper
+import com.polzzak_android.data.repository.LoginRepository
+import com.polzzak_android.presentation.auth.login.model.LoginConvertor.toLoginInfoUiModel
+import com.polzzak_android.presentation.auth.login.model.LoginInfoUiModel
+import com.polzzak_android.presentation.auth.model.SocialLoginType
+import com.polzzak_android.presentation.common.model.ApiResult
+import com.polzzak_android.presentation.common.util.toApiResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val loginRepository: LoginRepository
+) : ViewModel() {
+    private val _loginInfoLiveData = MutableLiveData<EventWrapper<ApiResult<LoginInfoUiModel>>>()
+    val loginInfoLiveData: LiveData<EventWrapper<ApiResult<LoginInfoUiModel>>> = _loginInfoLiveData
+
+
+    private var loginJob: Job? = null
+
+    fun requestGoogleLogin(authCode: String) {
+        if (loginJob?.isCompleted == false) return
+        loginJob = viewModelScope.launch {
+            val googleOAuthTokensDeferred =
+                async { loginRepository.requestGoogleAccessToken(authCode = authCode) }
+            val googleOAuthResponse = googleOAuthTokensDeferred.await()
+            val accessToken = googleOAuthResponse.body()?.accessToken
+            accessToken?.let {
+                requestLogin(accessToken = it, loginType = SocialLoginType.GOOGLE)
+            } ?: run {
+                Timber.d("google access token 발급 실패")
+                //TODO access token 발급 실패 callback
+            }
+        }
+    }
+
+    fun requestKakaoLogin(accessToken: String) {
+        if (loginJob?.isCompleted == false) return
+        loginJob = viewModelScope.launch {
+            requestLogin(accessToken = accessToken, loginType = SocialLoginType.KAKAO)
+        }
+    }
+
+    private suspend fun requestLogin(accessToken: String, loginType: SocialLoginType) {
+        _loginInfoLiveData.value = EventWrapper(ApiResult.loading())
+
+        val response =
+            loginRepository.requestLogin(accessToken = accessToken, loginType = loginType)
+        _loginInfoLiveData.value =
+            EventWrapper(response.toApiResult { loginResponse -> loginResponse?.toLoginInfoUiModel() })
+    }
+}

--- a/app/src/main/java/com/polzzak_android/presentation/auth/login/sociallogin/KakaoLoginHelper.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/auth/login/sociallogin/KakaoLoginHelper.kt
@@ -9,16 +9,20 @@ import timber.log.Timber
 
 //TODO 로그아웃 콜백 추가
 class KakaoLoginHelper(private val context: Context) {
-    private var loginSuccessCallback: ((token: OAuthToken) -> Unit)? = null
+    private var loginSuccessCallbacks: MutableList<(OAuthToken) -> Unit> = mutableListOf()
 
-    fun setLoginSuccessCallback(callback: (token: OAuthToken) -> Unit) {
-        loginSuccessCallback = callback
+    fun registerLoginSuccessCallback(callback: (token: OAuthToken) -> Unit) {
+        loginSuccessCallbacks.add(callback)
+    }
+
+    fun unregisterLoginSuccessCallback(callback: (OAuthToken) -> Unit): Boolean {
+        return loginSuccessCallbacks.removeIf { it == callback }
     }
 
     fun requestLogin() {
         with(UserApiClient.instance) {
             val kakaoLoginSuccessCallback: (OAuthToken) -> Unit =
-                { token -> loginSuccessCallback?.invoke(token) }
+                { token -> loginSuccessCallbacks.forEach { it.invoke(token) } }
             val kakaoLoginCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
                 if (error != null) {
                     //TODO 카카오 로그인 실패 에러 핸들링

--- a/app/src/main/java/com/polzzak_android/presentation/auth/login/sociallogin/SocialLoginManager.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/auth/login/sociallogin/SocialLoginManager.kt
@@ -1,6 +1,6 @@
 package com.polzzak_android.presentation.auth.login.sociallogin
 
 interface SocialLoginManager {
-    fun requestLoginGoogle()
-    fun requestLoginKakao()
+    val googleLoginHelper: GoogleLoginHelper?
+    val kakaoLoginHelper: KakaoLoginHelper?
 }

--- a/app/src/main/java/com/polzzak_android/presentation/auth/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/auth/signup/SignUpViewModel.kt
@@ -14,6 +14,7 @@ import com.polzzak_android.common.util.livedata.EventWrapper
 import com.polzzak_android.common.util.safeLet
 import com.polzzak_android.presentation.common.util.toApiResult
 import com.polzzak_android.data.repository.SignUpRepository
+import com.polzzak_android.data.repository.UserRepository
 import com.polzzak_android.presentation.auth.signup.model.MemberTypeUiModel
 import com.polzzak_android.presentation.auth.signup.model.NickNameUiModel
 import com.polzzak_android.presentation.auth.signup.model.NickNameValidationState
@@ -28,6 +29,7 @@ import kotlinx.coroutines.launch
 
 class SignUpViewModel @AssistedInject constructor(
     private val signUpRepository: SignUpRepository,
+    private val userRepository: UserRepository,
     @Assisted private val userName: String?, @Assisted private val userType: SocialLoginType?
 ) : ViewModel() {
     private val _pageLiveData = MutableLiveData<SignUpPage>()

--- a/app/src/main/java/com/polzzak_android/presentation/common/MainActivity.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/common/MainActivity.kt
@@ -20,8 +20,11 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), SocialLoginManager {
 
     private lateinit var navController: NavController
 
-    private var googleLoginHelper: GoogleLoginHelper? = null
-    private var kakaoLoginHelper: KakaoLoginHelper? = null
+    private var _googleLoginHelper: GoogleLoginHelper? = null
+    override val googleLoginHelper get() = _googleLoginHelper
+
+    private var _kakaoLoginHelper: KakaoLoginHelper? = null
+    override val kakaoLoginHelper get() = _kakaoLoginHelper
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
@@ -39,27 +42,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), SocialLoginManager {
     }
 
     private fun initLoginHelper() {
-        googleLoginHelper = GoogleLoginHelper(activity = this).apply {
-            setLoginSuccessCallback {
-                it.serverAuthCode?.let { authCode ->
-                    mainViewModel.requestGoogleLogin(authCode = authCode)
-                } ?: run {
-                    //TODO id값, authcode가 안내려온 경우
-                }
-            }
-        }
-        kakaoLoginHelper = KakaoLoginHelper(context = this).apply {
-            setLoginSuccessCallback { token ->
-                mainViewModel.requestKakaoLogin(accessToken = token.accessToken)
-            }
-        }
-    }
-
-    override fun requestLoginGoogle() {
-        googleLoginHelper?.requestLogin()
-    }
-
-    override fun requestLoginKakao() {
-        kakaoLoginHelper?.requestLogin()
+        _googleLoginHelper = GoogleLoginHelper(activity = this)
+        _kakaoLoginHelper = KakaoLoginHelper(context = this)
     }
 }

--- a/app/src/main/java/com/polzzak_android/presentation/common/MainViewModel.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/common/MainViewModel.kt
@@ -1,65 +1,13 @@
 package com.polzzak_android.presentation.common
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.polzzak_android.presentation.common.model.ApiResult
-import com.polzzak_android.presentation.auth.model.SocialLoginType
-import com.polzzak_android.presentation.common.model.UserInfo
-import com.polzzak_android.common.util.livedata.EventWrapper
-import com.polzzak_android.presentation.common.util.toApiResult
 import com.polzzak_android.data.repository.LoginRepository
-import com.polzzak_android.presentation.auth.login.model.LoginConvertor.toLoginInfoUiModel
-import com.polzzak_android.presentation.auth.login.model.LoginInfoUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val loginRepository: LoginRepository,
 ) : ViewModel() {
-    private val _loginInfoLiveData = MutableLiveData<EventWrapper<ApiResult<LoginInfoUiModel>>>()
-    val loginInfoLiveData: LiveData<EventWrapper<ApiResult<LoginInfoUiModel>>> = _loginInfoLiveData
 
-    private val _userInfoLiveData = MutableLiveData<ApiResult<UserInfo>>()
-    val userInfoLiveData: LiveData<ApiResult<UserInfo>> = _userInfoLiveData
-
-    private var loginJob: Job? = null
-
-    fun requestGoogleLogin(authCode: String) {
-        if (loginJob?.isCompleted == false) return
-        loginJob = viewModelScope.launch {
-            val googleOAuthTokensDeferred =
-                async { loginRepository.requestGoogleAccessToken(authCode = authCode) }
-            val googleOAuthResponse = googleOAuthTokensDeferred.await()
-            val accessToken = googleOAuthResponse.body()?.accessToken
-            accessToken?.let {
-                requestLogin(accessToken = it, loginType = SocialLoginType.GOOGLE)
-            } ?: run {
-                Timber.d("google access token 발급 실패")
-                //TODO access token 발급 실패 callback
-            }
-        }
-    }
-
-    fun requestKakaoLogin(accessToken: String) {
-        if (loginJob?.isCompleted == false) return
-        loginJob = viewModelScope.launch {
-            requestLogin(accessToken = accessToken, loginType = SocialLoginType.KAKAO)
-        }
-    }
-
-    private suspend fun requestLogin(accessToken: String, loginType: SocialLoginType) {
-        _loginInfoLiveData.value = EventWrapper(ApiResult.loading())
-
-        val response =
-            loginRepository.requestLogin(accessToken = accessToken, loginType = loginType)
-        _loginInfoLiveData.value =
-            EventWrapper(response.toApiResult { loginResponse -> loginResponse?.toLoginInfoUiModel() })
-    }
 }

--- a/app/src/main/java/com/polzzak_android/presentation/common/model/UserInfo.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/common/model/UserInfo.kt
@@ -1,11 +1,7 @@
 package com.polzzak_android.presentation.common.model
 
-import com.polzzak_android.presentation.auth.model.SocialLoginType
-
 data class UserInfo(
-    val userName: String,
-    val memberType: MemberType,
-    val socialType: SocialLoginType,
-    val nickName: String,
-    val profileUrl: String?
+    val memberType: MemberType? = null,
+    val nickName: String? = null,
+    val profileUrl: String? = null
 )

--- a/app/src/main/res/navigation/root_nav_graph.xml
+++ b/app/src/main/res/navigation/root_nav_graph.xml
@@ -7,6 +7,7 @@
 
     <include app:graph="@navigation/protector_nav_graph" />
     <include app:graph="@navigation/kid_nav_graph" />
+    <include app:graph="@navigation/sign_up_nav_graph" />
 
     <fragment
         android:id="@+id/splashFragment"
@@ -31,17 +32,10 @@
         <action
             android:id="@+id/action_loginFragment_to_kidHostFragment"
             app:destination="@id/kidHostFragment" />
-
         <action
             android:id="@+id/action_loginFragment_to_SignUpFragment"
-            app:destination="@id/signUpFragment" />
+            app:destination="@id/sign_up_nav_graph" />
     </fragment>
-
-    <fragment
-        android:id="@+id/signUpFragment"
-        android:name="com.polzzak_android.presentation.auth.signup.SignUpFragment"
-        android:label="SignUpFragment"
-        tools:layout="layout/fragment_signUp" />
 
     <fragment
         android:id="@+id/protectorHostFragment"

--- a/app/src/main/res/navigation/sign_up_nav_graph.xml
+++ b/app/src/main/res/navigation/sign_up_nav_graph.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/sign_up_nav_graph"
+    app:startDestination="@id/signUpFragment">
+
+    <fragment
+        android:id="@+id/signUpFragment"
+        android:name="com.polzzak_android.presentation.auth.signup.SignUpFragment"
+        android:label="SignUpFragment"
+        tools:layout="@layout/fragment_signup">
+        <action android:id="@+id/action_signUpFragment_to_kidOnBoardingFragment"
+            app:destination="@id/kidOnBoardingFragment"/>
+        <action android:id="@+id/action_signUpFragment_to_protectorOnBoardingFragment"/>
+    </fragment>
+
+    <fragment
+        android:id="@+id/kidOnBoardingFragment"
+        android:name="com.polzzak_android.presentation.onboarding.kid.KidOnBoardingFragment"
+        android:label="KidOnBoardingFragment"
+        tools:layout="@layout/fragment_on_boarding" />
+
+    <fragment
+        android:id="@+id/protectorOnBoardingFragment"
+        android:name="com.polzzak_android.presentation.onboarding.protector.ProtectorOnBoardingFragment"
+        android:label="ProtectorOnBoardingFragment"
+        tools:layout="@layout/fragment_on_boarding" />
+</navigation>


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- #37 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- signUp navigation 추가
- 로그인, 회원가입 요청부분 메인에서 분리(메인에서 데이터만 갖고있도록 변경)

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
