### PR TITLE
[FIX] 쿠폰 이미지 저장 시 crash 발생 수정

### DIFF
--- a/app/src/main/java/com/polzzak_android/presentation/component/dialog/CommonDialogHelper.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/component/dialog/CommonDialogHelper.kt
@@ -8,7 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.view.drawToBitmap
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.DialogFragment
 import com.polzzak_android.R
@@ -18,7 +18,6 @@ import com.polzzak_android.databinding.ItemDialogMissionListBinding
 import com.polzzak_android.presentation.common.util.BindableItem
 import com.polzzak_android.presentation.common.util.BindableItemAdapter
 import com.polzzak_android.presentation.common.util.getCurrentDate
-import com.polzzak_android.presentation.feature.coupon.detail.CouponTicketImage
 import com.polzzak_android.presentation.feature.stamp.model.MissionModel
 
 /**
@@ -106,7 +105,7 @@ class CommonDialogHelper(
         }
 
         if (content.type == DialogStyleType.CAPTURE) {
-            binding.ivCouponImage.setImageDrawable(content.content.captureView!!.drawable)
+            binding.ivCouponImage.setImageBitmap(content.content.captureBitmap)
         }
     }
 
@@ -147,6 +146,10 @@ class CommonDialogHelper(
 
             if (content.type == DialogStyleType.CALENDAR) {
                 onConfirmListener?.invoke()?.getReturnValue(selectedDate)
+            }
+
+            if (content.type == DialogStyleType.CAPTURE) {
+                onConfirmListener?.invoke()?.getReturnValue(binding.dialogCaptureFrame.drawToBitmap())
             }
             dismiss()
         }

--- a/app/src/main/java/com/polzzak_android/presentation/component/dialog/CommonDialogModel.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/component/dialog/CommonDialogModel.kt
@@ -1,8 +1,7 @@
 package com.polzzak_android.presentation.component.dialog
 
+import android.graphics.Bitmap
 import android.text.Spannable
-import android.view.View
-import android.widget.ImageView
 import com.polzzak_android.presentation.common.model.CommonButtonModel
 import com.polzzak_android.presentation.feature.stamp.model.MissionModel
 import java.util.Calendar
@@ -20,49 +19,49 @@ data class CommonDialogModel(
                 require(content.mission == null) { "Mission must be null for ALERT type" }
                 require(content.stampImg == null) { "Stamp image must be null for ALERT type" }
                 require(content.missionList == null) { "Mission list must be null for ALERT type" }
-                require(content.captureView == null) { "Capture view must be null for ALERT type" }
+                require(content.captureBitmap == null) { "Capture view must be null for ALERT type" }
             }
             DialogStyleType.CALENDAR -> {
                 require(content.calendar != null) { "Calendar must not be null for CALENDAR type" }
                 require(content.mission == null) { "Mission must be null for CALENDAR type" }
                 require(content.stampImg == null) { "Stamp image must be null for CALENDAR type" }
                 require(content.missionList == null) { "Mission list must be null for CALENDAR type" }
-                require(content.captureView == null) { "Capture view must be null for CALENDAR type" }
+                require(content.captureBitmap == null) { "Capture view must be null for CALENDAR type" }
             }
             DialogStyleType.MISSION -> {
                 require(content.calendar == null) { "Calendar must be null for MISSION type" }
                 require(content.mission != null) { "Mission must not be null for MISSION type" }
                 require(content.stampImg == null) { "Stamp image must be null for MISSION type" }
                 require(content.missionList == null) { "Mission list must be null for CALENDAR type" }
-                require(content.captureView == null) { "Capture view must be null for CALENDAR type" }
+                require(content.captureBitmap == null) { "Capture view must be null for CALENDAR type" }
             }
             DialogStyleType.LOADING -> {
                 require(content.calendar == null) { "Calendar must be null for LOADING type" }
                 require(content.mission == null) { "Mission must be null for LOADING type" }
                 require(content.stampImg == null) { "Stamp image must be null for LOADING type" }
                 require(content.missionList == null) { "Mission list must be null for LOADING type" }
-                require(content.captureView == null) { "Capture view must be null for LOADING type" }
+                require(content.captureBitmap == null) { "Capture view must be null for LOADING type" }
             }
             DialogStyleType.STAMP -> {
                 require(content.calendar == null) { "Calendar must be null for STAMP type" }
                 require(content.mission == null) { "Mission must be null for STAMP type" }
                 require(content.stampImg != null) { "Stamp image not be null for STAMP type" }
                 require(content.missionList == null) { "Mission list must be null for STAMP type" }
-                require(content.captureView == null) { "Capture view must be null for STAMP type" }
+                require(content.captureBitmap == null) { "Capture view must be null for STAMP type" }
             }
             DialogStyleType.MISSION_LIST -> {
                 require(content.calendar == null) { "Calendar must be null for MISSION LIST type" }
                 require(content.mission == null) { "Mission must be null for MISSION LIST type" }
                 require(content.stampImg == null) { "Stamp image must be null for MISSION LIST type" }
                 require(content.missionList != null) { "Mission list not be null for MISSION LIST type" }
-                require(content.captureView == null) { "Capture view must be null for MISSION LIST type" }
+                require(content.captureBitmap == null) { "Capture view must be null for MISSION LIST type" }
             }
             DialogStyleType.CAPTURE -> {
                 require(content.calendar == null) { "Calendar must be null for CAPTURE type" }
                 require(content.mission == null) { "Mission must be null for CAPTURE type" }
                 require(content.stampImg == null) { "Stamp image must be null for CAPTURE type" }
                 require(content.missionList == null) { "Mission list must be null for CAPTURE type" }
-                require(content.captureView != null) { "Capture view must not be null for CAPTURE type" }
+                require(content.captureBitmap != null) { "Capture view must not be null for CAPTURE type" }
             }
         }
     }
@@ -75,7 +74,7 @@ data class CommonDialogContent(
     val mission: CommonDialogMissionData? = null,
     val stampImg: Int? = null,
     val missionList: List<MissionModel>? = null,
-    val captureView: ImageView? = null
+    val captureBitmap: Bitmap? = null
 )
 
 data class CommonDialogMissionData(

--- a/app/src/main/java/com/polzzak_android/presentation/feature/coupon/detail/kid/KidCouponDetailFragment.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/feature/coupon/detail/kid/KidCouponDetailFragment.kt
@@ -1,5 +1,6 @@
 package com.polzzak_android.presentation.feature.coupon.detail.kid
 
+import android.graphics.Bitmap
 import android.widget.ImageView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.text.toSpannable
@@ -84,16 +85,13 @@ class KidCouponDetailFragment : BaseFragment<FragmentCouponDetailBinding>(), Too
 
         // 화면에 나타난 쿠폰 View를 비트맵으로 변환
         val bitmap = couponImageView?.drawToBitmap()
-        val imageView = ImageView(requireContext()).apply {
-            setImageBitmap(bitmap!!)
-        }
 
         CommonDialogHelper.getInstance(
             content = CommonDialogModel(
                 type = DialogStyleType.CAPTURE,
                 content = CommonDialogContent(
                     title = "다음 쿠폰을 사진첩에 저장합니다.".toSpannable(),
-                    captureView = imageView
+                    captureBitmap = bitmap
                 ),
                 button = CommonButtonModel(
                     buttonCount = ButtonCount.TWO,
@@ -104,7 +102,10 @@ class KidCouponDetailFragment : BaseFragment<FragmentCouponDetailBinding>(), Too
             onConfirmListener = {
                 object : OnButtonClickListener {
                     override fun setBusinessLogic() {
-                        val couponBitmap = imageView.drawToBitmap()
+                    }
+
+                    override fun getReturnValue(value: Any) {
+                        val couponBitmap = value as Bitmap
 
                         lifecycleScope.launch {
                             saveBitmapToGallery(couponBitmap)
@@ -119,9 +120,6 @@ class KidCouponDetailFragment : BaseFragment<FragmentCouponDetailBinding>(), Too
                                         .show()
                                 }
                         }
-                    }
-
-                    override fun getReturnValue(value: Any) {
                     }
                 }
             }


### PR DESCRIPTION
issue: #123

* 원인: 이미지로 저장할 View 자체를 화면에 표시하지 않아 Bitmap으로 변환하지 못해 Exception 발생
* 해결: 쿠폰 이미지를 Bitmap으로 전달해 다이얼로그에 표시하고, 확인 클릭 시 저장할 View를 bitmap으로 반환받아 저장하도록 변경

## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #123 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
