### PR TITLE
[FIX] 쿠폰함 메뉴 선택시 crash 발생

### DIFF
--- a/app/src/main/java/com/polzzak_android/data/remote/model/response/CouponListResponse.kt
+++ b/app/src/main/java/com/polzzak_android/data/remote/model/response/CouponListResponse.kt
@@ -1,9 +1,13 @@
 package com.polzzak_android.data.remote.model.response
 
+import com.polzzak_android.presentation.common.util.dateBetween
+import com.polzzak_android.presentation.common.util.toLocalDateOrNull
 import com.polzzak_android.presentation.feature.coupon.model.Coupon
 import com.polzzak_android.presentation.feature.coupon.model.CouponModel
 import com.polzzak_android.presentation.feature.coupon.model.CouponPartner
 import java.text.SimpleDateFormat
+import java.time.Duration
+import java.time.LocalDate
 import java.util.Calendar
 
 data class CouponListResponse(
@@ -58,12 +62,13 @@ fun CouponDto.toCouponModel(isKid: Boolean) = CouponModel(
 )
 
 fun getRemainDay(rewardDay: String): String {
-    val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS")
-    val targetDate = dateFormat.parse(rewardDay)
+    val targetDate = rewardDay.toLocalDateOrNull() ?: LocalDate.now()
 
-    val today = Calendar.getInstance().time
-
-    val differenceInMillis = targetDate.time - today.time
-
-    return (differenceInMillis / (1000 * 60 * 60 * 24)).toString()
+    return Duration
+        .between(
+            LocalDate.now().atStartOfDay(),
+            targetDate.atStartOfDay()
+        )
+        .toDays()
+        .toString()
 }

--- a/app/src/main/java/com/polzzak_android/presentation/common/adapter/MainCouponPagerAdapter.kt
+++ b/app/src/main/java/com/polzzak_android/presentation/common/adapter/MainCouponPagerAdapter.kt
@@ -4,9 +4,12 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.polzzak_android.databinding.ItemCouponBinding
+import com.polzzak_android.presentation.common.util.toLocalDateOrNull
 import com.polzzak_android.presentation.feature.coupon.main.content.CouponContainerInteraction
 import com.polzzak_android.presentation.feature.coupon.model.CouponModel
 import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 class MainCouponPagerAdapter(
     private var couponList: List<CouponModel>,
@@ -46,6 +49,8 @@ class MainCouponPagerAdapter(
         private val giftRequest = binding.couponGiftRequest
         private val giftFinish = binding.couponGiftFinish
 
+        private val deadlineTextFormat = DateTimeFormatter.ofPattern("yyyy.MM.dd까지 주기로 약속했어요")
+
         fun bind(item: CouponModel) {
             isKid = item.isKid
             dDay.text = item.dDay
@@ -66,12 +71,9 @@ class MainCouponPagerAdapter(
         }
 
         private fun deadlineFormat(deadline: String): String {
-            val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS")
-            val targetDate = inputFormat.parse(deadline)
+            val targetDate = deadline.toLocalDateOrNull() ?: LocalDate.now()
 
-            val outputFormat = SimpleDateFormat("yyyy.MM.dd까지 주기로 약속했어요")
-
-            return outputFormat.format(targetDate)
+            return targetDate.format(deadlineTextFormat)
         }
     }
 


### PR DESCRIPTION
issue: #150

- 원인: 쿠폰함 화면 표시하면서 서버에서 받은 시간 string을 parse하는데 format이 잘못 지정되어있어서 exception 발생하여 crash
- 해결: 올바르게 parse해주는 확장함수 사용하는 것으로 수정

## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #150 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
